### PR TITLE
Changes in support of ZK/GCC update to binder/nameservice

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "deps/libcbuf"]
 	path = deps/libcbuf
-	url = https://github.com/bowrocker/libcbuf.git
-        branch = jra-zk-3.4.11
+	url = https://github.com/joyent/libcbuf.git
 [submodule "deps/illumos-list"]
 	path = deps/illumos-list
 	url = https://github.com/joyent/illumos-list.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/libcbuf"]
 	path = deps/libcbuf
-	url = https://github.com/jclulow/libcbuf.git
+	url = https://github.com/bowrocker/libcbuf.git
 [submodule "deps/illumos-list"]
 	path = deps/illumos-list
 	url = https://github.com/joyent/illumos-list.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "deps/libcbuf"]
 	path = deps/libcbuf
 	url = https://github.com/bowrocker/libcbuf.git
+        branch = jra-zk-3.4.11
 [submodule "deps/illumos-list"]
 	path = deps/illumos-list
 	url = https://github.com/joyent/illumos-list.git

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright (c) 2018, Joyent, Inc.
+# Copyright (c) 2020, Joyent, Inc.
 #
 
 TOP =		$(PWD)
@@ -46,7 +46,7 @@ DEPS_CFLAGS +=	-pthread
 
 OBJ_DIR =	$(TOP)/obj
 
-CTFCONVERT =	/opt/ctf/bin/ctfconvert
+CTFCONVERT =	/bin/true
 CC =		gcc
 GIT =		git
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright (c) 2020, Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 TOP =		$(PWD)
@@ -35,7 +35,7 @@ INCS =		$(TOP)/deps/illumos-list/include \
 		$(TOP)/deps/libcloop/include \
 		$(TOP)/deps/illumos-bunyan/include
 
-CFLAGS =	-Wall -Wextra -Werror \
+CFLAGS =	-Wall -m64 -Wextra -Werror \
 		-Wno-unused-parameter \
 		-std=c99 -D__EXTENSIONS__ -pthread \
 		-O0 -gdwarf-2 \

--- a/deps/illumos-bunyan/Makefile
+++ b/deps/illumos-bunyan/Makefile
@@ -27,7 +27,7 @@ $(PROVIDER_H): $(PROVIDER_D) | $(BUILD_DIR)
 	$(DTRACE) -h -o $@ -s $<
 
 $(PROVIDER_O): $(PROVIDER_D) $(OBJECTS) | $(BUILD_DIR)
-	$(DTRACE) -32 -G -o $@ -s $< $(OBJECTS)
+	$(DTRACE) -G -o $@ -s $< $(OBJECTS)
 
 $(BUILD_DIR):
 	mkdir -p $@

--- a/deps/libcloop/src/cserver.c
+++ b/deps/libcloop/src/cserver.c
@@ -613,8 +613,8 @@ cconn_on_write(cloop_ent_t *clent, int ev)
 			continue;
 		}
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] WRITE DATA: HAVE %d; "
-			    "Q %d\n", ccn, want,
+			fprintf(stderr, "CCONN[%p] WRITE DATA: HAVE %ld; "
+			    "Q %ld\n", ccn, want,
 			    cbufq_available(ccn->ccn_sendq));
 		}
 
@@ -696,7 +696,7 @@ cconn_on_read(cloop_ent_t *clent, int ev)
 		 * wakeup and go back to sleep without rearming.
 		 */
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] READ TOO MUCH (%d)\n", ccn,
+			fprintf(stderr, "CCONN[%p] READ TOO MUCH (%ld)\n", ccn,
 			    av);
 		}
 		return;
@@ -710,7 +710,7 @@ cconn_on_read(cloop_ent_t *clent, int ev)
 		cbuf_resume(cbuf);
 		VERIFY(cbuf_available(cbuf) > 8);
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] REUSE BUF %p (UNUSED %u)\n",
+			fprintf(stderr, "CCONN[%p] REUSE BUF %p (UNUSED %lu)\n",
 			    ccn, cbuf, cbuf_available(cbuf));
 		}
 	} else {
@@ -723,7 +723,7 @@ cconn_on_read(cloop_ent_t *clent, int ev)
 		}
 		cbuf_byteorder_set(cbuf, ccn->ccn_order);
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] ALLOC BUF %p (UNUSED %u)\n",
+			fprintf(stderr, "CCONN[%p] ALLOC BUF %p (UNUSED %lu)\n",
 			    ccn, cbuf, cbuf_available(cbuf));
 		}
 	}
@@ -759,7 +759,7 @@ retry:
 			fprintf(stderr, "CCONN[%p] READ EOF\n", ccn);
 		}
 	} else if (cserver_debug) {
-		fprintf(stderr, "CCONN[%p] READ %u BYTES\n", ccn, actual);
+		fprintf(stderr, "CCONN[%p] READ %lu BYTES\n", ccn, actual);
 	}
 
 	cbuf_flip(cbuf);

--- a/deps/libcloop/src/cserver.c
+++ b/deps/libcloop/src/cserver.c
@@ -613,8 +613,8 @@ cconn_on_write(cloop_ent_t *clent, int ev)
 			continue;
 		}
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] WRITE DATA: HAVE %ld; "
-			    "Q %ld\n", ccn, want,
+			fprintf(stderr, "CCONN[%p] WRITE DATA: HAVE %zd; "
+			    "Q %zd\n", ccn, want,
 			    cbufq_available(ccn->ccn_sendq));
 		}
 
@@ -696,7 +696,7 @@ cconn_on_read(cloop_ent_t *clent, int ev)
 		 * wakeup and go back to sleep without rearming.
 		 */
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] READ TOO MUCH (%ld)\n", ccn,
+			fprintf(stderr, "CCONN[%p] READ TOO MUCH (%zd)\n", ccn,
 			    av);
 		}
 		return;
@@ -710,7 +710,7 @@ cconn_on_read(cloop_ent_t *clent, int ev)
 		cbuf_resume(cbuf);
 		VERIFY(cbuf_available(cbuf) > 8);
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] REUSE BUF %p (UNUSED %lu)\n",
+			fprintf(stderr, "CCONN[%p] REUSE BUF %p (UNUSED %zu)\n",
 			    ccn, cbuf, cbuf_available(cbuf));
 		}
 	} else {
@@ -723,7 +723,7 @@ cconn_on_read(cloop_ent_t *clent, int ev)
 		}
 		cbuf_byteorder_set(cbuf, ccn->ccn_order);
 		if (cserver_debug) {
-			fprintf(stderr, "CCONN[%p] ALLOC BUF %p (UNUSED %lu)\n",
+			fprintf(stderr, "CCONN[%p] ALLOC BUF %p (UNUSED %zu)\n",
 			    ccn, cbuf, cbuf_available(cbuf));
 		}
 	}
@@ -759,7 +759,7 @@ retry:
 			fprintf(stderr, "CCONN[%p] READ EOF\n", ccn);
 		}
 	} else if (cserver_debug) {
-		fprintf(stderr, "CCONN[%p] READ %lu BYTES\n", ccn, actual);
+		fprintf(stderr, "CCONN[%p] READ %zu BYTES\n", ccn, actual);
 	}
 
 	cbuf_flip(cbuf);

--- a/udp_proxy.c
+++ b/udp_proxy.c
@@ -131,7 +131,7 @@ another_packet:
 again:
 	if (cbuf_sys_recvfrom(buf, cloop_ent_fd(ent),
 	    CBUF_SYSREAD_ENTIRE, &rsz, 0, (struct sockaddr *)&from,
-	    &fromlen) != 0) {
+	    (size_t *)&fromlen) != 0) {
 		switch (errno) {
 		case EINTR:
 			goto again;


### PR DESCRIPTION
With the [update](https://github.com/joyent/binder/pull/14), the GCC version is 7.4.0. This PR fixes compilation and platform errors.

Note: the dependency on libcbuf, currently in a personal repo, should be forked into the Joyent org before this PR merges.